### PR TITLE
Fix 'Anchor Navigation' for new Visual Studio Code versions

### DIFF
--- a/src/providers/YamlDefinitionProvider.ts
+++ b/src/providers/YamlDefinitionProvider.ts
@@ -43,7 +43,13 @@ export class YamlDefinitionProvider implements vscode.DefinitionProvider {
         );
         this.logger.log(`Word at position: ${word}`);
 
-        if (!word.startsWith('*')) {
+        const start = wordRange.start
+        var anchorName;
+        if (word.startsWith('*')) {
+            anchorName = word.substring(1);
+        } else if (document.getText(wordRange.with(start.translate(0, -1), start)) === '*') {
+            anchorName = word
+        } else {
             this.logger.log('No anchor found (does not start with "*")');
             return undefined;
         }
@@ -58,7 +64,6 @@ export class YamlDefinitionProvider implements vscode.DefinitionProvider {
                 this.logger.log(`Reading file: ${fullPath}`);
                 const fileContent = fs.readFileSync(fullPath, 'utf8');
 
-                const anchorName = word.substring(1);
                 const anchorPattern = new RegExp(`&${anchorName}\\b`, 'm');
 
                 const match = fileContent.match(anchorPattern);


### PR DESCRIPTION
In last versions of Visual Studio Code (e.g. 1.106.0) with default setting 'Anchor Navigation' logic doesn't work. It doesn't work because (`document.getText(...)`)[https://code.visualstudio.com/api/references/vscode-api#TextDocument] at line 39 of `YamlDefinitionProvider.ts` returns just the anchor name without `*`.  With default settings Visual Studio Code consider `*` as word separator and cuts if off.

Fix is made in such a way not to break plugin for old Visual Studio Code versions users and those users that might have configured `*` as not a word separator symbol for YAML format.